### PR TITLE
Fix: Crashed when CKEditor 4 objects were in toolbar config

### DIFF
--- a/private/js/cms.ckeditor5.js
+++ b/private/js/cms.ckeditor5.js
@@ -282,7 +282,7 @@ class CmsCKEditor5Plugin {
                 }
 
                 // Add (if applicable)
-                if (Array.isArray(item)) {
+                if (Array.isArray(item) || Array.isArray[item.items]) {
                     if (addingToBlock) {
                         if (blockToolbar.length > 0) {
                             blockToolbar.push('|');
@@ -290,7 +290,7 @@ class CmsCKEditor5Plugin {
                     } else if (topToolbar.length > 0) {
                         topToolbar.push('|');
                     }
-                    buildToolbars(item);
+                    buildToolbars(Array.isArray[item] ? item : item.items);
                 } else if (inline && ['ShowBlocks', 'SourceEditing'].includes(item)) {
                     // No source editing or show blocks in inline editor
                     continue;
@@ -311,7 +311,7 @@ class CmsCKEditor5Plugin {
                     } else {
                         topToolbar.push(item);
                     }
-                } else if (this._blockItems.includes(item.toLowerCase()) && inline) {
+                } else if (typeof item === 'string' && this._blockItems.includes(item.toLowerCase()) && inline) {
                     blockToolbar.push(item);
                     addingToBlock = true;
                 } else {

--- a/private/js/cms.ckeditor5.js
+++ b/private/js/cms.ckeditor5.js
@@ -282,7 +282,7 @@ class CmsCKEditor5Plugin {
                 }
 
                 // Add (if applicable)
-                if (Array.isArray(item) || Array.isArray[item.items]) {
+                if (Array.isArray(item) || Array.isArray(item.items)) {
                     if (addingToBlock) {
                         if (blockToolbar.length > 0) {
                             blockToolbar.push('|');
@@ -290,7 +290,7 @@ class CmsCKEditor5Plugin {
                     } else if (topToolbar.length > 0) {
                         topToolbar.push('|');
                     }
-                    buildToolbars(Array.isArray[item] ? item : item.items);
+                    buildToolbars(Array.isArray(item) ? item : item.items);
                 } else if (inline && ['ShowBlocks', 'SourceEditing'].includes(item)) {
                     // No source editing or show blocks in inline editor
                     continue;


### PR DESCRIPTION
Setting:
```
   'toolbar_CMS': [
        {'name': 'clipboard', 'items': ['Undo', 'Redo', '-', 'Cut', 'Copy', 'Paste', 'PasteText']},
        {'name': 'editing', 'items': ['Find', '-', 'Scayt']},        
        ['cmsplugins', '-','Anchor'], # 'ShowBlocks'],        
        ['Maximize', ''],
        '/',
        ['Bold', 'Italic', 'Underline', '-', 'Subscript', 'Superscript', '-', 'RemoveFormat', 'FontSize', 'TextColor', 'BGColor'],
        ['JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock'],       
        ['NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'HorizontalRule', '-', 'Table'],
         #['Link', 'Unlink'],['Image'],
        ['Source']
    ],
```

![image](https://github.com/user-attachments/assets/d4a9ff26-2c89-4dc2-9734-0d9d231b51bb)
